### PR TITLE
ci: add GitHub Actions CI mirroring PatientManager

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -89,16 +89,13 @@ Display the validated candidate:
 
 ## Step 3 — Draft body
 
-1. Run `git log --oneline $(git merge-base HEAD main)..HEAD` and collect all commit messages.
+1. Run `git log --oneline $(git merge-base HEAD main)..HEAD` and collect all commit messages — used as **input** to summarise what changed; do NOT enumerate them in the PR body. GitHub's Commits tab already provides this view, and squash-merge configs (PR_TITLE + BLANK body) discard the PR body anyway, so an inline commit list is duplication + drift risk every time a new commit is pushed.
 2. Check for a plan doc: `Glob docs/plan/*-plan.md`. If one matches the branch domain, `Read` it and extract the feature description from the top section.
 3. Produce a body in this format — keep it concise:
 
 ```
 ## Summary
 {2–4 bullet points summarising what changed, derived from commits or plan}
-
-## Commits
-{one line per commit from git log, oldest first}
 
 ## Test plan
 - [ ] {inferred from commit messages, plan doc, or reviewer steps completed}

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -38,7 +38,8 @@ if [ ${#TITLE} -gt 72 ]; then
 fi
 
 # RULE 4: No trailing period
-# Trim trailing whitespace to catch "feat: add feature. " cases
+# Trim trailing whitespace to catch "feat: add feature. " cases.
+# shellcheck disable=SC2001  # bash parameter expansion for trim-trailing-ws is unreadable
 TITLE_TRIMMED=$(echo "$TITLE" | sed 's/[[:space:]]*$//')
 if [[ "$TITLE_TRIMMED" == *. ]]; then
     echo -e "${RED}❌ Title must not end with a period${NC}"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -31,7 +31,10 @@ fi
 # not refactor to a pipe (the subshell + SIGPIPE interaction breaks this).
 DELETE_ONLY=true
 HAS_REFS=false
-while read -r local_ref local_sha remote_ref remote_sha; do
+# Only $local_sha is read — _local_ref / _remote_ref / _remote_sha are
+# placeholders for the rest of the stdin format. The underscore prefix
+# tells shellcheck the unused-ness is intentional (SC2034).
+while read -r _local_ref local_sha _remote_ref _remote_sha; do
     HAS_REFS=true
     if [[ ! "$local_sha" =~ ^0+$ ]]; then
         DELETE_ONLY=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,114 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize, reopened]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pr-title:
+    name: PR title (conventional commits)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      pull-requests: read
+    steps:
+      # Pinned to full SHA for v6.1.1 — mutable tags are a supply-chain risk.
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            refactor
+            test
+            ci
+
+  commits:
+    name: Commit messages (mirrors commit-msg hook)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Validate every commit in the PR
+        run: |
+          set -u
+          BASE=$(git merge-base HEAD origin/main)
+          FAIL=0
+          REGEX='^(feat|fix|docs|test|chore|refactor|ci)(\([^)]+\))?!?: .+'
+          # --no-merges skips the synthetic merge commit GitHub creates at
+          # HEAD for pull_request events (it represents "what main looks
+          # like if this PR merged" — not a real PR commit).
+          for sha in $(git rev-list --no-merges "$BASE..HEAD"); do
+            TITLE=$(git log -1 --pretty=%s "$sha")
+            BODY=$(git log -1 --pretty=%b "$sha")
+
+            if ! echo "$TITLE" | grep -E "$REGEX" >/dev/null; then
+              echo "::error::$sha — invalid conventional format: $TITLE"
+              FAIL=1
+            fi
+            if [ ${#TITLE} -gt 72 ]; then
+              echo "::error::$sha — title > 72 chars (${#TITLE}): $TITLE"
+              FAIL=1
+            fi
+            TRIMMED=$(echo "$TITLE" | sed 's/[[:space:]]*$//')
+            if [[ "$TRIMMED" == *. ]]; then
+              echo "::error::$sha — title ends with period: $TITLE"
+              FAIL=1
+            fi
+            BODY_LINES=$(echo "$BODY" | { grep -v '^$' || true; } | { grep -v '^BREAKING CHANGE:' || true; } | wc -l)
+            if [ "$BODY_LINES" -gt 5 ]; then
+              echo "::error::$sha — body > 5 lines ($BODY_LINES): $TITLE"
+              FAIL=1
+            fi
+            if echo "$BODY" | grep -i '^Co-Authored-By:' >/dev/null; then
+              echo "::error::$sha — contains Co-Authored-By trailer: $TITLE"
+              FAIL=1
+            fi
+          done
+          if [ "$FAIL" -eq 0 ]; then
+            echo "✅ All commits pass the commit-msg hook rules."
+          fi
+          exit "$FAIL"
+
+  quality:
+    name: Quality (python3 scripts/check.py)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install Python tools
+        run: pip install --quiet ruff
+      - name: Install shfmt
+        run: sudo apt-get update -qq && sudo apt-get install -y shfmt
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install Prettier
+        run: npm install --global --silent prettier
+      - name: Run kit checks
+        run: python3 scripts/check.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           exit "$FAIL"
 
   quality:
-    name: Quality (python3 scripts/check.py)
+    name: Quality (check.py + lint-scripts)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -110,5 +110,9 @@ jobs:
           node-version: "22"
       - name: Install Prettier
         run: npm install --global --silent prettier
+      - name: Install just
+        uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6  # v3.0.0
       - name: Run kit checks
         run: python3 scripts/check.py
+      - name: Lint kit-shipped scripts (biome + ruff + shellcheck)
+        run: just lint-scripts

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,9 +1,5 @@
 # List of TODOs
 
-## v4.6 candidates
-
-_All v4.6 candidates resolved — see commit history. Remaining work is in v4.7._
-
 ## v4.7 candidates
 
 - **SDD Workflow B walk — verify reviewer dual-use.** Reviewer agents (`reviewer-arch`, `reviewer-backend`, `reviewer-frontend`, `reviewer-e2e`, `reviewer-sql`, `reviewer-infra`, `reviewer-security`) are used by both Workflow A (Phase 4) and Workflow B (step 5). Workflow B has no `docs/plan/{feature}-plan.md`, no `docs/contracts/{domain}-contract.md`, no `docs/spec/{domain}.md`. Verify each reviewer handles the no-plan / no-contract context gracefully (no hard reads, no halts on absent files). Likely surface mostly verification with small graceful-skip patches.

--- a/justfile
+++ b/justfile
@@ -20,7 +20,9 @@ lint-scripts:
     fail=0
     mjs=$(find kit/scripts -maxdepth 1 -type f \( -name '*.mjs' -o -name '*.js' \) | sort)
     py=$(find kit/scripts -maxdepth 1 -type f -name '*.py' | sort)
-    sh=$(find kit/scripts -maxdepth 1 -type f -name '*.sh' | sort)
+    # Include kit/sync-config.sh — the bootstrap script ships once to downstream
+    # as scripts/sync-config.sh but lives outside kit/scripts/.
+    sh=$( { find kit/scripts -maxdepth 1 -type f -name '*.sh'; echo kit/sync-config.sh; } | sort)
     if [ -n "$mjs" ]; then
         echo "▶ biome check (lineWidth=100): $(echo "$mjs" | wc -l) file(s)"
         # shellcheck disable=SC2086  # word-splitting intentional for the file list

--- a/justfile
+++ b/justfile
@@ -7,7 +7,38 @@ format:
     ruff format scripts/ kit/scripts/
     ruff check --fix scripts/ kit/scripts/
     shfmt -i 4 -w kit/scripts/ kit/githooks/ kit/sync-config.sh
+    npx --yes @biomejs/biome check --write --line-width=100 kit/scripts/
     npx prettier --write "**/*.md" --ignore-path .gitignore
+
+# Lint kit-shipped scripts against tool defaults — catches files that would
+# fail downstream linters at first sync. biome (recommended + lineWidth=100),
+# ruff (kit-default selection), shellcheck (default). No project config; CLI
+# flags only — the kit is not a Node/Python project, only ships scripts.
+lint-scripts:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    fail=0
+    mjs=$(find kit/scripts -maxdepth 1 -type f \( -name '*.mjs' -o -name '*.js' \) | sort)
+    py=$(find kit/scripts -maxdepth 1 -type f -name '*.py' | sort)
+    sh=$(find kit/scripts -maxdepth 1 -type f -name '*.sh' | sort)
+    if [ -n "$mjs" ]; then
+        echo "▶ biome check (lineWidth=100): $(echo "$mjs" | wc -l) file(s)"
+        # shellcheck disable=SC2086  # word-splitting intentional for the file list
+        npx --yes @biomejs/biome check --line-width=100 $mjs || fail=1
+    fi
+    if [ -n "$py" ]; then
+        echo "▶ ruff check + format --check: $(echo "$py" | wc -l) file(s)"
+        # shellcheck disable=SC2086
+        ruff check $py || fail=1
+        # shellcheck disable=SC2086
+        ruff format --check $py || fail=1
+    fi
+    if [ -n "$sh" ]; then
+        echo "▶ shellcheck: $(echo "$sh" | wc -l) file(s)"
+        # shellcheck disable=SC2086
+        shellcheck $sh || fail=1
+    fi
+    exit "$fail"
 
 stat:
     cloc . --vcs=git

--- a/kit/agents/reviewer-infra.md
+++ b/kit/agents/reviewer-infra.md
@@ -116,7 +116,7 @@ Skip silently any file or directory below that does not exist in the project (v4
 
 - 🔴 `GITHUB_TOKEN` with `contents: write` must not be combined with `pull_request` trigger from forks (injection risk)
 - 🔴 Secrets must never be echoed, logged, or passed to untrusted actions
-- 🔴 Third-party actions must be pinned to a commit SHA, not a mutable tag like `@v1` or `@latest` — **exception**: internal/trusted actions explicitly approved by the team (e.g. `tauri-apps/tauri-action@v0`, `Swatinem/rust-cache@v2`, `dtolnay/rust-toolchain@stable`, `actions/checkout@v4`, `actions/setup-node@v4`) are allowed with version tags
+- 🔴 Third-party actions must be pinned to a commit SHA, not a mutable tag like `@v1` or `@latest` — **exception**: internal/trusted actions explicitly approved by the team (e.g. `tauri-apps/tauri-action@v0`, `Swatinem/rust-cache@v2`, `dtolnay/rust-toolchain@stable`, `actions/checkout@v4`, `actions/setup-node@v4`, `actions/setup-python@v5`) are allowed with version tags
 - 🔴 `actions: write` permission is required when using `gh cache delete`
 - 🟡 `permissions` block should follow least-privilege: only grant what the job actually needs
 - 🟡 `workflow_dispatch` inputs of type `choice` should have a `default` value

--- a/kit/githooks/commit-msg
+++ b/kit/githooks/commit-msg
@@ -38,7 +38,8 @@ if [ ${#TITLE} -gt 72 ]; then
 fi
 
 # RULE 4: No trailing period
-# Trim trailing whitespace to catch "feat: add feature. " cases
+# Trim trailing whitespace to catch "feat: add feature. " cases.
+# shellcheck disable=SC2001  # bash parameter expansion for trim-trailing-ws is unreadable
 TITLE_TRIMMED=$(echo "$TITLE" | sed 's/[[:space:]]*$//')
 if [[ "$TITLE_TRIMMED" == *. ]]; then
     echo -e "${RED}❌ Title must not end with a period${NC}"

--- a/kit/githooks/pre-push
+++ b/kit/githooks/pre-push
@@ -31,7 +31,10 @@ fi
 # not refactor to a pipe (the subshell + SIGPIPE interaction breaks this).
 DELETE_ONLY=true
 HAS_REFS=false
-while read -r local_ref local_sha remote_ref remote_sha; do
+# Only $local_sha is read — _local_ref / _remote_ref / _remote_sha are
+# placeholders for the rest of the stdin format. The underscore prefix
+# tells shellcheck the unused-ness is intentional (SC2034).
+while read -r _local_ref local_sha _remote_ref _remote_sha; do
     HAS_REFS=true
     if [[ ! "$local_sha" =~ ^0+$ ]]; then
         DELETE_ONLY=false

--- a/kit/scripts/check.py
+++ b/kit/scripts/check.py
@@ -98,8 +98,6 @@ class QualityChecker:
         # Stack markers — presence-of-file gates each check.
         # Partial-stack projects (e.g. no-DB Tauri, FE-only, kit-only bootstrap)
         # skip the gated checks instead of failing.
-        # TODO(v4.7): strict mode should treat absent stack as failure.
-        # See `docs/TODO.md` § "Partial-stack & strict-mode audit (no-DB Tauri)".
         self.package_json = self.repo_root / "package.json"
         self.cargo_toml = self.repo_root / "src-tauri" / "Cargo.toml"
         self.sqlx_dir = self.repo_root / "src-tauri" / ".sqlx"

--- a/kit/scripts/sync.sh
+++ b/kit/scripts/sync.sh
@@ -21,9 +21,8 @@ trap 'rm -rf "$TMP"' EXIT
 
 # Colors (respect NO_COLOR=1)
 if [ -n "${NO_COLOR:-}" ]; then
-    YELLOW='' GREEN='' BLUE='' NC=''
+    GREEN='' BLUE='' NC=''
 else
-    YELLOW='\033[0;33m'
     GREEN='\033[0;32m'
     BLUE='\033[0;34m'
     NC='\033[0m'

--- a/kit/scripts/validate-sync.sh
+++ b/kit/scripts/validate-sync.sh
@@ -18,9 +18,8 @@ MANIFEST="$PROJECT_ROOT/.claude/kit-manifest.txt"
 
 # Colors (respect NO_COLOR=1)
 if [ -n "${NO_COLOR:-}" ]; then
-    YELLOW='' GREEN='' RED='' BLUE='' NC=''
+    GREEN='' RED='' BLUE='' NC=''
 else
-    YELLOW='\033[0;33m'
     GREEN='\033[0;32m'
     RED='\033[0;31m'
     BLUE='\033[0;34m'

--- a/kit/scripts/visual-proof-capture.mjs
+++ b/kit/scripts/visual-proof-capture.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 /**
  * Playwright capture script for the /visual-proof skill.
  *
@@ -21,8 +22,8 @@
  * Exit codes: 0 ok, 2 usage error (missing env), 1 runtime/Playwright error.
  */
 
-import { chromium } from "playwright";
 import { mkdir, writeFile } from "node:fs/promises";
+import { chromium } from "playwright";
 
 const PORT = process.env.VP_PORT;
 const HOST = process.env.VP_HOST;
@@ -31,8 +32,8 @@ const STATES = (process.env.VP_STATES || "idle").split(",");
 const MASK_SELECTORS = (process.env.VP_MASK || "").split(",").filter(Boolean);
 
 if (!PORT || !HOST || !NAME) {
-  console.error("error: VP_PORT, VP_HOST, and VP_NAME are required");
-  process.exit(2);
+	console.error("error: VP_PORT, VP_HOST, and VP_NAME are required");
+	process.exit(2);
 }
 
 const consoleErrors = [];
@@ -40,51 +41,46 @@ await mkdir("screenshots", { recursive: true });
 
 const browser = await chromium.launch({ args: ["--no-sandbox"] });
 try {
-  for (const scheme of ["light", "dark"]) {
-    const context = await browser.newContext({
-      colorScheme: scheme,
-      viewport: { width: 1600, height: 900 },
-    });
-    try {
-      const page = await context.newPage();
+	for (const scheme of ["light", "dark"]) {
+		const context = await browser.newContext({
+			colorScheme: scheme,
+			viewport: { width: 1600, height: 900 },
+		});
+		try {
+			const page = await context.newPage();
 
-      page.on("console", (msg) => {
-        if (msg.type() === "error") {
-          consoleErrors.push({ scheme, text: msg.text() });
-        }
-      });
+			page.on("console", (msg) => {
+				if (msg.type() === "error") {
+					consoleErrors.push({ scheme, text: msg.text() });
+				}
+			});
 
-      const url = `http://${HOST}:${PORT}/preview.html${
-        scheme === "dark" ? "?theme=dark" : ""
-      }`;
-      await page.goto(url, { waitUntil: "domcontentloaded" });
-      await page.waitForSelector(`#state-${STATES[0]}`, { timeout: 10000 });
+			const url = `http://${HOST}:${PORT}/preview.html${scheme === "dark" ? "?theme=dark" : ""}`;
+			await page.goto(url, { waitUntil: "domcontentloaded" });
+			await page.waitForSelector(`#state-${STATES[0]}`, { timeout: 10000 });
 
-      const masks = MASK_SELECTORS.map((sel) => page.locator(sel));
+			const masks = MASK_SELECTORS.map((sel) => page.locator(sel));
 
-      for (const state of STATES) {
-        const el = page.locator(`#state-${state}`);
-        if ((await el.count()) > 0) {
-          const path = `screenshots/${NAME}-${scheme}-${state}.png`;
-          await el.screenshot({ path, mask: masks });
-          console.error(`  → ${path}`);
-        }
-      }
-    } finally {
-      await context.close();
-    }
-  }
+			for (const state of STATES) {
+				const el = page.locator(`#state-${state}`);
+				if ((await el.count()) > 0) {
+					const path = `screenshots/${NAME}-${scheme}-${state}.png`;
+					await el.screenshot({ path, mask: masks });
+					console.error(`  → ${path}`);
+				}
+			}
+		} finally {
+			await context.close();
+		}
+	}
 
-  if (consoleErrors.length > 0) {
-    console.error("\n⚠️  Console errors detected during capture:");
-    for (const err of consoleErrors) {
-      console.error(`  [${err.scheme}] ${err.text}`);
-    }
-    await writeFile(
-      "screenshots/.console-errors.json",
-      JSON.stringify(consoleErrors, null, 2),
-    );
-  }
+	if (consoleErrors.length > 0) {
+		console.error("\n⚠️  Console errors detected during capture:");
+		for (const err of consoleErrors) {
+			console.error(`  [${err.scheme}] ${err.text}`);
+		}
+		await writeFile("screenshots/.console-errors.json", JSON.stringify(consoleErrors, null, 2));
+	}
 } finally {
-  await browser.close();
+	await browser.close();
 }

--- a/kit/skills/create-pr/SKILL.md
+++ b/kit/skills/create-pr/SKILL.md
@@ -89,16 +89,13 @@ Display the validated candidate:
 
 ## Step 3 — Draft body
 
-1. Run `git log --oneline $(git merge-base HEAD main)..HEAD` and collect all commit messages.
+1. Run `git log --oneline $(git merge-base HEAD main)..HEAD` and collect all commit messages — used as **input** to summarise what changed; do NOT enumerate them in the PR body. GitHub's Commits tab already provides this view, and squash-merge configs (PR_TITLE + BLANK body) discard the PR body anyway, so an inline commit list is duplication + drift risk every time a new commit is pushed.
 2. Check for a plan doc: `Glob docs/plan/*-plan.md`. If one matches the branch domain, `Read` it and extract the feature description from the top section.
 3. Produce a body in this format — keep it concise:
 
 ```
 ## Summary
 {2–4 bullet points summarising what changed, derived from commits or plan}
-
-## Commits
-{one line per commit from git log, oldest first}
 
 ## Test plan
 - [ ] {inferred from commit messages, plan doc, or reviewer steps completed}

--- a/scripts/validate-sync.sh
+++ b/scripts/validate-sync.sh
@@ -18,9 +18,8 @@ MANIFEST="$PROJECT_ROOT/.claude/kit-manifest.txt"
 
 # Colors (respect NO_COLOR=1)
 if [ -n "${NO_COLOR:-}" ]; then
-    YELLOW='' GREEN='' RED='' BLUE='' NC=''
+    GREEN='' RED='' BLUE='' NC=''
 else
-    YELLOW='\033[0;33m'
     GREEN='\033[0;32m'
     RED='\033[0;31m'
     BLUE='\033[0;34m'


### PR DESCRIPTION
## Summary
Adds the project's first CI workflow and closes a downstream-friction loophole on kit-shipped scripts.

- **CI workflow** (`.github/workflows/ci.yml`) — three jobs on PRs to main: PR title (conventional commits via SHA-pinned amannn action), per-commit validation mirroring the kit's `commit-msg` hook, and `python3 scripts/check.py` + `just lint-scripts` on Ubuntu.
- **`just lint-scripts`** runs biome (lineWidth=100), ruff, and shellcheck against `kit/scripts/`. Catches files that would fail downstream linters at first sync — the trigger case was biome flagging `visual-proof-capture.mjs`'s unsorted imports on a VaultCompass sync.
- **`just format`** extended with `biome --write` so the auto-fix counterpart covers the new lint surface.
- Auto-fixed `kit/scripts/visual-proof-capture.mjs` to biome-clean (the trigger case).
- Cleared 7 shellcheck warnings surfaced when CI first ran (locally silent because shellcheck wasn't installed; now is, for parity).
- `create-pr` skill dropped its `## Commits` template section — GitHub's Commits tab provides the same view canonically and the squash-merge config discards the PR body anyway, so the inline list was pure duplication that drifted on every push.

## Test plan
- [x] CI runs green on this PR (this PR *is* the smoke test for the workflow itself)
- [x] `just lint-scripts` exits 0 on the current scripts tree
- [x] Deliberately-broken `.mjs` (unsorted imports) fails the recipe locally
- [x] No kit-root config drift (no `package.json`, `pyproject.toml`, `biome.json`)
- [ ] Squash-merge with PR_TITLE only → single-line entry on main
- [ ] Cut v4.7.2 after merge
