### PR TITLE
fix(docs): drop compound shell from test_convention.md example

### DIFF
--- a/kit/docs/test_convention.md
+++ b/kit/docs/test_convention.md
@@ -13,7 +13,7 @@ Run checks before committing:
 
 ```bash
 npm run test                   # Frontend (Vitest)
-cd src-tauri && cargo test     # Backend (Rust)
+cargo test --manifest-path src-tauri/Cargo.toml   # Backend (Rust)
 <your-check-command>           # Full check: lint + type-check + tests
 ```
 


### PR DESCRIPTION
Follow-up to #38 / v4.7.3. One-line doc fix.

## Summary
`kit/docs/test_convention.md:16` shows `cd src-tauri && cargo test` as the Rust-test example — same compound-shell anti-pattern v4.7.3 swept out of agents/skills, just at the convention-doc layer (out of scope for the existing lint rule). Swap to the allowlistable form `cargo test --manifest-path src-tauri/Cargo.toml`, matching what `test-writer-backend.md` already uses.

## Test plan
- [x] `python3 scripts/check.py` green
- [ ] CI green
- [ ] Cherry-pick to svelte-main after merge (same one-line change in `kit/docs/test_convention-svelte.md`)
