### PR TITLE
fix: v4.12 — gh#54 reviewer fanout + gh#53 whats-next drift

### DIFF
--- a/kit/agents/reviewer-arch.md
+++ b/kit/agents/reviewer-arch.md
@@ -64,9 +64,9 @@ If invoked with no in-scope files in the branch diff, halt with the refusal in `
 
 ### Step 1 — Discover changed files
 
-Run `bash scripts/branch-files.sh | grep -E '\.(rs|ts|tsx)$' | grep -v '^e2e/'`. If the result is empty, halt — output the no-files refusal and stop.
+Run `bash scripts/branch-files.sh --arch`. If the result is empty, halt — output the no-files refusal and stop.
 
-The `grep -v '^e2e/'` is critical — E2E test files are `reviewer-e2e`'s lane and must not be reviewed here. Scenarios are imperative WebdriverIO calls, not feature-architecture surfaces.
+The `--arch` filter excludes `e2e/` paths — E2E test files are `reviewer-e2e`'s lane and must not be reviewed here. Scenarios are imperative WebdriverIO calls, not feature-architecture surfaces.
 
 Filter out deleted paths: for each candidate, confirm the file exists with `Glob` before adding it to the review set. Deletes are out of scope for this agent — a removed file cannot violate layering on lines that no longer exist; if a deletion broke a downstream contract (e.g. a removed gateway), that surfaces in the file that still exists.
 

--- a/kit/agents/reviewer-backend.md
+++ b/kit/agents/reviewer-backend.md
@@ -62,7 +62,7 @@ If invoked with no `.rs` files in the branch diff, halt with the refusal in `## 
 
 ### Step 1 — Discover changed Rust files
 
-Run `bash scripts/branch-files.sh | grep -E '\.rs$'`. If the result is empty, halt — output the no-rust-files refusal and stop.
+Run `bash scripts/branch-files.sh --rust`. If the result is empty, halt — output the no-rust-files refusal and stop.
 
 Filter out deleted paths (their content can't be read): for each candidate, confirm the file exists with `Glob` before adding it to the review set.
 

--- a/kit/agents/reviewer-e2e.md
+++ b/kit/agents/reviewer-e2e.md
@@ -60,7 +60,7 @@ If no E2E test files match, halt with the refusal in `## Output format`.
 
 ### Step 1 — Discover changed E2E test files
 
-Run `bash scripts/branch-files.sh | grep -E '^e2e/.*\.test\.ts$'`. If the result is empty, halt — output the empty-result refusal in `## Output format` and stop.
+Run `bash scripts/branch-files.sh --e2e`. If the result is empty, halt — output the empty-result refusal in `## Output format` and stop.
 
 Filter out deleted paths (their content can't be read): for each candidate, confirm the file exists with `Glob` before adding it to the review set.
 

--- a/kit/agents/reviewer-frontend.md
+++ b/kit/agents/reviewer-frontend.md
@@ -65,7 +65,7 @@ If no `.ts` / `.tsx` files under `src/` are in the branch diff, halt with the re
 
 ### Step 1 — Discover changed frontend files
 
-Run `bash scripts/branch-files.sh | grep -E '\.(ts|tsx)$' | grep -v '^e2e/'`. The `grep -v '^e2e/'` is critical — E2E test files are `reviewer-e2e`'s lane and must not be reviewed here. If the result is empty, halt — output the empty-result refusal in `## Output format` and stop.
+Run `bash scripts/branch-files.sh --frontend`. The `--frontend` filter excludes `e2e/` paths — E2E test files are `reviewer-e2e`'s lane and must not be reviewed here. If the result is empty, halt — output the empty-result refusal in `## Output format` and stop.
 
 Filter out deleted paths (their content can't be read): for each candidate, confirm the file exists with `Glob` before adding it to the review set.
 

--- a/kit/agents/reviewer-security.md
+++ b/kit/agents/reviewer-security.md
@@ -78,7 +78,7 @@ If invoked with no in-scope files in the branch diff, halt with the refusal in `
 
 ### Step 1 — Discover security-relevant files
 
-Run `bash scripts/branch-files.sh | grep -E '\.(rs|ts|tsx)$|capabilities/.*\.json$'`. If the result is empty, halt — output the no-files refusal and stop.
+Run `bash scripts/branch-files.sh --security`. If the result is empty, halt — output the no-files refusal and stop.
 
 Filter out deleted paths: confirm each candidate exists with `Glob` before adding it to the review set. Deletes are out of scope — a removed file cannot host security issues on lines that no longer exist.
 

--- a/kit/agents/reviewer-sql.md
+++ b/kit/agents/reviewer-sql.md
@@ -65,7 +65,7 @@ If invoked with no migration files in the branch diff, halt with the refusal in 
 
 ### Step 1 — Discover changed migration files
 
-Run `bash scripts/branch-files.sh | grep '^migrations/'`. If the result is empty, halt — output the no-migrations refusal and stop.
+Run `bash scripts/branch-files.sh --migrations`. If the result is empty, halt — output the no-migrations refusal and stop.
 
 The kit's SQLx convention pins migrations to `migrations/` at the repo root. Projects using a different layout must override this agent's discovery in a local fork, not rely on a runtime branch.
 

--- a/kit/kit-readme.md
+++ b/kit/kit-readme.md
@@ -170,6 +170,18 @@ The kit's reviewer-\* agents save their full output to `.review/{slug}-{date}-{N
 
 `.review/` is created automatically the first time any reviewer runs; the folder name is fixed (the scripts hard-code the path so the skill can find them). If you need to wipe accumulated reports, `rm -rf .review/` is safe — the next reviewer run rebuilds the directory.
 
+**Suggested `.claude/settings.local.json` allowlist** — silences a permission prompt on every reviewer save:
+
+```jsonc
+{
+  "permissions": {
+    "allow": ["Write(.review/**)"],
+  },
+}
+```
+
+Without this entry, each reviewer run prompts once per unique report path (3+ prompts on a multi-reviewer batch).
+
 ### Authoring rule — no compound shell in agent / skill prompts
 
 Bash blocks inside agents (`kit/agents/*.md`) and skills (`kit/skills/*/SKILL.md`) **must not** contain compound shell. Specifically, the following patterns are rejected by `scripts/check.py`'s `No compound shell in prompts` rule:

--- a/kit/scripts/branch-files.sh
+++ b/kit/scripts/branch-files.sh
@@ -6,16 +6,57 @@ set -euo pipefail
 # changes. Use in review agents that run after commits are already made.
 #
 # Use:
-#   bash scripts/branch-files.sh
-#   bash scripts/branch-files.sh | grep -E '\.(rs|ts|tsx)$'
+#   bash scripts/branch-files.sh                # all changed files
+#   bash scripts/branch-files.sh --rust         # *.rs
+#   bash scripts/branch-files.sh --frontend     # *.ts / *.tsx, excluding e2e/
+#   bash scripts/branch-files.sh --arch         # *.rs / *.ts / *.tsx, excluding e2e/
+#   bash scripts/branch-files.sh --e2e          # e2e/**/*.test.ts
+#   bash scripts/branch-files.sh --migrations   # migrations/*
+#   bash scripts/branch-files.sh --security     # *.rs / *.ts / *.tsx OR capabilities/**/*.json
+#
+# The named filters exist so reviewer-* agent prompts can call a single literal
+# command (no shell pipe) — Claude Code's permission allowlist matches by
+# literal prefix, and `branch-files.sh | grep ...` triggers a fresh permission
+# prompt on every distinct shape. One `Bash(bash scripts/branch-files.sh *)`
+# entry covers every filtered invocation.
 #
 # Output: one path per line, alphabetically sorted, deduplicated, no headers.
 
+FILTER='.'
+EXCLUDE=''
+case "${1:-}" in
+"") ;;
+--rust) FILTER='\.rs$' ;;
+--frontend)
+    FILTER='\.(ts|tsx)$'
+    EXCLUDE='^e2e/'
+    ;;
+--arch)
+    FILTER='\.(rs|ts|tsx)$'
+    EXCLUDE='^e2e/'
+    ;;
+--e2e) FILTER='^e2e/.*\.test\.ts$' ;;
+--migrations) FILTER='^migrations/' ;;
+--security) FILTER='\.(rs|ts|tsx)$|capabilities/.*\.json$' ;;
+*)
+    echo "usage: bash scripts/branch-files.sh [--rust|--frontend|--arch|--e2e|--migrations|--security]" >&2
+    exit 2
+    ;;
+esac
+
 BASE=$(bash "$(dirname "$0")/branch.sh" base)
 
-{
-    git diff --name-only "$BASE"..HEAD
-    git diff --name-only HEAD
-    git diff --name-only --cached
-    git status --porcelain | awk '/^\?\?/ {print $2}'
-} | sort -u | grep -v '^$' || true
+collect() {
+    {
+        git diff --name-only "$BASE"..HEAD
+        git diff --name-only HEAD
+        git diff --name-only --cached
+        git status --porcelain | awk '/^\?\?/ {print $2}'
+    } | sort -u | grep -v '^$' || true
+}
+
+if [ -n "$EXCLUDE" ]; then
+    collect | grep -E "$FILTER" | grep -v -E "$EXCLUDE" || true
+else
+    collect | grep -E "$FILTER" || true
+fi

--- a/kit/scripts/whats-next.py
+++ b/kit/scripts/whats-next.py
@@ -416,13 +416,17 @@ def _latest_kit_tag() -> str | None:
         # the JSON stdout consumer must stay clean.
         # OSError: covers the TOCTOU window between shutil.which() and execve
         # (broken symlink, permission flip).
+        # /releases/latest 404s on this kit (we publish via git tags only, not
+        # GitHub Releases). Query /tags and filter to strict `vX.Y.Z` shape —
+        # excludes svelte-lineage tags (`svelte-vX.Y.Z+M.N.P`) and any future
+        # pre-release tags. GitHub returns tags in newest-first order.
         result = subprocess.run(
             [
                 "gh",
                 "api",
-                f"repos/{KIT_REPO}/releases/latest",
+                f"repos/{KIT_REPO}/tags",
                 "--jq",
-                ".tag_name",
+                r'map(.name | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")))[0]',
             ],
             check=True,
             stdout=subprocess.PIPE,

--- a/scripts/branch-files.sh
+++ b/scripts/branch-files.sh
@@ -6,16 +6,57 @@ set -euo pipefail
 # changes. Use in review agents that run after commits are already made.
 #
 # Use:
-#   bash scripts/branch-files.sh
-#   bash scripts/branch-files.sh | grep -E '\.(rs|ts|tsx)$'
+#   bash scripts/branch-files.sh                # all changed files
+#   bash scripts/branch-files.sh --rust         # *.rs
+#   bash scripts/branch-files.sh --frontend     # *.ts / *.tsx, excluding e2e/
+#   bash scripts/branch-files.sh --arch         # *.rs / *.ts / *.tsx, excluding e2e/
+#   bash scripts/branch-files.sh --e2e          # e2e/**/*.test.ts
+#   bash scripts/branch-files.sh --migrations   # migrations/*
+#   bash scripts/branch-files.sh --security     # *.rs / *.ts / *.tsx OR capabilities/**/*.json
+#
+# The named filters exist so reviewer-* agent prompts can call a single literal
+# command (no shell pipe) — Claude Code's permission allowlist matches by
+# literal prefix, and `branch-files.sh | grep ...` triggers a fresh permission
+# prompt on every distinct shape. One `Bash(bash scripts/branch-files.sh *)`
+# entry covers every filtered invocation.
 #
 # Output: one path per line, alphabetically sorted, deduplicated, no headers.
 
+FILTER='.'
+EXCLUDE=''
+case "${1:-}" in
+"") ;;
+--rust) FILTER='\.rs$' ;;
+--frontend)
+    FILTER='\.(ts|tsx)$'
+    EXCLUDE='^e2e/'
+    ;;
+--arch)
+    FILTER='\.(rs|ts|tsx)$'
+    EXCLUDE='^e2e/'
+    ;;
+--e2e) FILTER='^e2e/.*\.test\.ts$' ;;
+--migrations) FILTER='^migrations/' ;;
+--security) FILTER='\.(rs|ts|tsx)$|capabilities/.*\.json$' ;;
+*)
+    echo "usage: bash scripts/branch-files.sh [--rust|--frontend|--arch|--e2e|--migrations|--security]" >&2
+    exit 2
+    ;;
+esac
+
 BASE=$(bash "$(dirname "$0")/branch.sh" base)
 
-{
-    git diff --name-only "$BASE"..HEAD
-    git diff --name-only HEAD
-    git diff --name-only --cached
-    git status --porcelain | awk '/^\?\?/ {print $2}'
-} | sort -u | grep -v '^$' || true
+collect() {
+    {
+        git diff --name-only "$BASE"..HEAD
+        git diff --name-only HEAD
+        git diff --name-only --cached
+        git status --porcelain | awk '/^\?\?/ {print $2}'
+    } | sort -u | grep -v '^$' || true
+}
+
+if [ -n "$EXCLUDE" ]; then
+    collect | grep -E "$FILTER" | grep -v -E "$EXCLUDE" || true
+else
+    collect | grep -E "$FILTER" || true
+fi

--- a/scripts/whats-next.py
+++ b/scripts/whats-next.py
@@ -416,13 +416,17 @@ def _latest_kit_tag() -> str | None:
         # the JSON stdout consumer must stay clean.
         # OSError: covers the TOCTOU window between shutil.which() and execve
         # (broken symlink, permission flip).
+        # /releases/latest 404s on this kit (we publish via git tags only, not
+        # GitHub Releases). Query /tags and filter to strict `vX.Y.Z` shape —
+        # excludes svelte-lineage tags (`svelte-vX.Y.Z+M.N.P`) and any future
+        # pre-release tags. GitHub returns tags in newest-first order.
         result = subprocess.run(
             [
                 "gh",
                 "api",
-                f"repos/{KIT_REPO}/releases/latest",
+                f"repos/{KIT_REPO}/tags",
                 "--jq",
-                ".tag_name",
+                r'map(.name | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")))[0]',
             ],
             check=True,
             stdout=subprocess.PIPE,


### PR DESCRIPTION
## Summary

- Reviewer Step 1 prompts now call `bash scripts/branch-files.sh --MODE`
  instead of piping through `grep` — Claude Code's allowlist matches by
  literal prefix, so `| grep ...` triggered a fresh permission prompt per
  pipe shape (closes gh#54 Source 1).
- `/whats-next` detects kit drift via `/tags` instead of `/releases/latest`
  (kit publishes via git tags only; endpoint silently 404'd) — closes gh#53.
- kit-readme documents `Write(.review/**)` allowlist suggestion to silence
  the per-report permission prompt on multi-reviewer batches (closes gh#54
  Source 3).

## Test plan

- [x] `python3 scripts/check.py` — all checks green
- [x] All filter modes (`--rust|--frontend|--arch|--e2e|--migrations|--security`) smoke-tested
- [x] `whats-next.py` end-to-end against real kit `/tags` returns `v4.11.0`
- [ ] Downstream sync to a real project confirms fewer permission prompts
- [ ] All checks pass (`just check-full`)
