### PR TITLE
feat(svelte): port v4.14.0 to svelte-main

### DIFF
--- a/docs/svelte-mirror-log.md
+++ b/docs/svelte-mirror-log.md
@@ -6,6 +6,31 @@ This file lives on `svelte-main` only — never cherry-picked back to `main`.
 
 ---
 
+## svelte-v0.8.0+4.13.0 → svelte-v0.9.0+4.14.0
+
+Baseline: `+4.13.0`. New baseline: `+4.14.0`. v4.14 substance is **FE rules + workflow polish** — gh#62 (TaskCreate now Step 5 in `/start`), gh#63 (F28 Store kinds: BE/FE shared cache → `infra/cache/`, FE-persisted settings → `infra/settings/`), gh#64 (reviewer-frontend F26 cross-feature store detector). Also a new deterministic `check.py` lint preventing future gh#62-class drift. Cherry-picked `c441e86..700a71a` (4 commits, dropped the `chore: release v4.14.0` commit on the usual conflict).
+
+### Mirrored to `-svelte` variants
+
+- `kit/docs/frontend-rules-svelte.md` — applied F28 Store kinds + F26 promotion target + infra/ exclusion tightening + F0 tree update with Svelte filenames. Translations: `Zustand singleton` → `Svelte store singleton (writable / Svelte 5 runes)`; `useCacheStore.ts` → `cacheStore.svelte.ts`; `useSettingsStore.ts` → `settingsStore.svelte.ts`. Architectural concept (3 store kinds, 3 homes, cross-feature reads via gateway) is framework-neutral and applies identically.
+- `kit/agents/reviewer-frontend-svelte.md` — applied F26 promotion-target update + F28 widget-local wording verbatim. Translated the F26 cross-feature store-import detector: React's `useXStore` symbol-shape regex doesn't apply to Svelte (no naming convention), so switched to a path-based detector — `grep -rE 'import\s+\{[^}]*\}\s+from\s+"@/features/[^/"]+/store(\.svelte)?"'`. Same path-scope rule and remediation message.
+
+### Shared (cherry-pick applies as-is)
+
+- `kit/skills/start/SKILL.md` — TaskCreate Step 5 + imperative blockquotes; framework-neutral workflow.
+- `scripts/check.py` — new `_check_skills_with_checklists_seed_tasks` lint; kit-only (not synced).
+- React canonicals (`kit/agents/reviewer-frontend.md`, `kit/docs/frontend-rules.md`) — cherry-pick lands their React-form updates; the Svelte forks above carry the Svelte-form mirror.
+
+### Skipped (React-specific)
+
+- _None._ Every v4.14 concept transfers; only wording needed translation.
+
+### Custom (manual treatment)
+
+- _None._
+
+---
+
 ## svelte-v0.7.0+4.12.0 → svelte-v0.8.0+4.13.0
 
 Baseline: `+4.12.0`. New baseline: `+4.13.0`. v4.13 substance is **kit reliability**: `sync-config.sh` flag-parsing rework (`-y`/`-h`, fail-loud on unknown), `whats-next.py` per-stream `kit_update` detection (closes gh#59 — the false `behind: true` on Svelte projects this branch is most affected by), stale-bootstrap detector + recovery recipe, and a release/merge/sync script hardening pass. All 5 commits are framework-neutral; cherry-pick `821ff3d..620cb27` applies as-is.

--- a/kit/agents/reviewer-frontend-svelte.md
+++ b/kit/agents/reviewer-frontend-svelte.md
@@ -139,8 +139,12 @@ The v4.5 error pipeline runs gateway → hook → presenter → component, each 
 ### Cross-feature imports (F23 navigation + F26 imports)
 
 - Inter-feature navigation NOT through the router (the router's navigation API, route paths) — flag direct cross-feature page-component renders (🔴, F23)
-- **Behaviour import** from a sibling feature (reactive module, store) — code smell; promote to `ui/modules/` or `shell/` instead (🟡, F26)
+- **Behaviour import** from a sibling feature (reactive module, store) — code smell; promote per F26 (reactive modules → `ui/modules/`; stores → `infra/cache/` or `infra/settings/`) (🟡, F26)
 - **Primitive import** from a sibling feature (type, pure function, presentational component) — fine; do not flag (F26)
+- **Cross-feature store import** (specific F26 case) (🟡, F26):
+  - _Grep_: `grep -rE 'import\s+\{[^}]*\}\s+from\s+"@/features/[^/"]+/store(\.svelte)?"' src/features/` — Svelte stores have no `useXStore` naming convention, so detect by PATH (any import from another feature's `store` or `store.svelte` module) rather than symbol shape.
+  - _Path scope_: flag only when the importing file is under `src/features/<self>/` AND the import path's `<other>` segment differs from `<self>`. `App.svelte` and `shell/` legitimately import feature stores — do not flag those.
+  - _Remediation_: the imported store is behaviour, not a primitive. Two valid fixes: (a) promote the shared cache to `infra/cache/` and have each feature's gateway expose its own selectors over it (per F28's Store kinds table); (b) keep the data backend-side and orchestrate via a use-case command.
 
 ### Top-level `src/` bucket compliance (F28)
 
@@ -151,7 +155,7 @@ The v4.5 four-bucket layout has both inclusion AND exclusion rules. Flag misclas
 - A domain term in a file under `ui/` (🟡 — `ui/` is domain-agnostic)
 - A pure helper or formatter in `infra/` instead of `ui/format/` (🟡)
 - A generic UI reactive module in `infra/` instead of `ui/modules/` (🟡)
-- A stateful UI runtime in `infra/` instead of colocated with its widget in `ui/components/` (🟡)
+- A widget-local UI runtime in `infra/` instead of colocated with its widget in `ui/components/` (🟡 — `infra/` holds app-wide singletons per F28's Store kinds; widget-local runtime belongs with the widget)
 - Stale path: `src/modules/` instead of `src/ui/modules/` (🟡 — F28 rename)
 
 ### Accessibility — i18n labels (F24)

--- a/kit/agents/reviewer-frontend.md
+++ b/kit/agents/reviewer-frontend.md
@@ -139,8 +139,12 @@ The v4.5 error pipeline runs gateway → hook → presenter → component, each 
 ### Cross-feature imports (F23 navigation + F26 imports)
 
 - Inter-feature navigation NOT through the router (`useNavigate`, route paths) — flag direct cross-feature page-component renders (🔴, F23)
-- **Behaviour import** from a sibling feature (hook, store) — code smell; promote to `ui/hooks/` or `shell/` instead (🟡, F26)
+- **Behaviour import** from a sibling feature (hook, store) — code smell; promote per F26 (hooks → `ui/hooks/`; stores → `infra/cache/` or `infra/settings/`) (🟡, F26)
 - **Primitive import** from a sibling feature (type, pure function, presentational component) — fine; do not flag (F26)
+- **Cross-feature store import** (specific F26 case) (🟡, F26):
+  - _Grep_: `grep -rP 'import\s+\{[^}]*\buse(?:[A-Z][A-Za-z0-9]*)?Store\b[^}]*\}\s+from\s+"@/features/' src/features/` — the optional `(?:[A-Z][A-Za-z0-9]*)?` middle catches both `usePatientStore` and bare `useStore` (Zustand single-store-per-feature convention).
+  - _Path scope_: flag only when the importing file is under `src/features/<self>/` AND `<self> != <other>`. `App.tsx` and `shell/` legitimately import feature stores — do not flag those.
+  - _Remediation_: the imported store is behaviour, not a primitive. Two valid fixes: (a) promote the shared cache to `infra/cache/` and have each feature's gateway expose its own selectors over it (per F28's Store kinds table); (b) keep the data backend-side and orchestrate via a use-case command.
 
 ### Top-level `src/` bucket compliance (F28)
 
@@ -151,7 +155,7 @@ The v4.5 four-bucket layout has both inclusion AND exclusion rules. Flag misclas
 - A domain term in a file under `ui/` (🟡 — `ui/` is domain-agnostic)
 - A pure helper or formatter in `infra/` instead of `ui/format/` (🟡)
 - A generic UI hook in `infra/` instead of `ui/hooks/` (🟡)
-- A stateful UI runtime in `infra/` instead of colocated with its widget in `ui/components/` (🟡)
+- A widget-local UI runtime in `infra/` instead of colocated with its widget in `ui/components/` (🟡 — `infra/` holds app-wide singletons per F28's Store kinds; widget-local runtime belongs with the widget)
 - Stale path: `src/hooks/` instead of `src/ui/hooks/` (🟡 — F28 rename)
 
 ### Accessibility — i18n labels (F24)

--- a/kit/docs/frontend-rules-svelte.md
+++ b/kit/docs/frontend-rules-svelte.md
@@ -36,14 +36,18 @@ src/
 │   └── modules/                       ← generic reactive modules (.svelte.ts)
 │       └── fuzzySearch.svelte.ts
 │
-├── infra/                             ← platform adapters ONLY (F15)
+├── infra/                             ← platform adapters + app-wide singleton state (F15, F28)
 │   ├── logger.ts                      ← native / console logger sink
-│   └── i18n/                          ← F16 i18n runtime adapter
-│       ├── index.ts                   ← setupI18n() initializer
-│       ├── config.ts
-│       └── locales/                   ← translation JSON files (per i18n-rules.md)
-│           └── {locale}/
-│               └── common.json
+│   ├── i18n/                          ← F16 i18n runtime adapter
+│   │   ├── index.ts                   ← setupI18n() initializer
+│   │   ├── config.ts
+│   │   └── locales/                   ← translation JSON files (per i18n-rules.md)
+│   │       └── {locale}/
+│   │           └── common.json
+│   ├── cache/                         ← BE/FE shared data cache (Svelte store singleton, F28 Store kinds)
+│   │   └── cacheStore.svelte.ts
+│   └── settings/                      ← FE-persisted UI prefs (theme, locale, layout)
+│       └── settingsStore.svelte.ts
 │
 ├── assets/                            ← images, fonts, SVGs imported by code (framework exception)
 ├── styles/                            ← global CSS, theme tokens (framework exception)
@@ -64,9 +68,25 @@ Each bucket's mandate:
 - **`features/`** — User-facing surfaces, organised per F1. A feature MAY own a gateway. **REJECTS:** anything reusable across features (promote to `ui/`) or any cross-cutting platform adapter (promote to `infra/`). A feature folder appearing anywhere else in the tree (e.g. inside `infra/` or `ui/`) is a misclassification.
 - **`shell/`** — Layout chrome ONLY: AppShell, persistent header/sidebar/content slot, app-level overlay hosts (snackbar mount point, modal portal target). Single instance per app, not reusable. **REJECTS:** `App.svelte` (root), `Router.svelte` (root), anything reusable (`ui/`), anything feature-scoped (`features/`).
 - **`ui/`** — Reusable UI primitives: widgets in `ui/components/`, cross-feature formatters in `ui/format/`, generic reactive modules in `ui/modules/`. Widget runtime state colocates with the widget (e.g. `ui/components/snackbar/snackbarStore.svelte.ts`). **REJECTS:** any domain term, any Tauri call (no `commands.*` from `ui/`), any platform adapter (`infra/`).
-- **`infra/`** — Platform adapters ONLY: code that talks to a runtime outside our control (logger sink, browser storage, i18n runtime, native bridges). **REJECTS:** pure helpers and formatters (promote to `ui/format/`), generic UI reactive modules (promote to `ui/modules/`), stateful UI runtime (colocate with the widget in `ui/components/`), anything feature-scoped (`features/`).
+- **`infra/`** — Platform adapters AND app-wide singleton state. Platform adapters: code that talks to a runtime outside our control (logger sink, browser storage, i18n runtime, native bridges). App-wide state: BE/FE shared data cache (`infra/cache/`), FE-persisted settings (`infra/settings/`) — see **Store kinds** below. **REJECTS:** pure helpers and formatters (promote to `ui/format/`), generic UI reactive modules (promote to `ui/modules/`), widget-local UI runtime (colocate with the widget in `ui/components/`), anything feature-scoped (`features/`).
 
 When a file lands in the wrong bucket, the exclusion rule of the destination bucket is what flags it.
+
+### Store kinds
+
+Stateful UI state has three legitimate homes, distinguished by scope:
+
+| Kind                   | Description                          | Home                           |
+| ---------------------- | ------------------------------------ | ------------------------------ |
+| BE/FE shared cache     | Singleton of backend-projection data | `infra/cache/`                 |
+| FE-persisted settings  | UI prefs (theme, locale, layout)     | `infra/settings/`              |
+| Feature-local UI state | Single-feature draft/modal state     | `features/{x}/store.svelte.ts` |
+
+The shared cache is seeded by initial fetches and updated via Tauri events. Cross-feature reads of the shared cache MUST go through each feature's own gateway (which reads selectors from the cache); direct cross-feature store imports remain a SHOULD-NOT per **F26**.
+
+Svelte stores in `infra/cache/` and `infra/settings/` use Svelte 5 runes (`.svelte.ts` files exporting `$state`-backed singletons) or `writable()`/`readable()` from `svelte/store` — both are acceptable; pick one per project and keep it consistent.
+
+Widget-local runtime state (e.g. snackbar mount internals) stays colocated with the widget in `ui/components/`. The `infra/` exclusion above refers only to that widget-local case — app-wide singletons are explicitly included.
 
 **Framework-resource exception.** Static resources owned by the framework (not by application code) sit outside the 4-bucket discipline because the industry-standard Svelte/Vite convention is well-established and tools (build, bundler, dev server) expect those paths:
 
@@ -313,6 +333,6 @@ The only authorised cross-feature navigation wiring points are:
 **F26** — Cross-feature imports are evaluated by what is imported, not by the fact of crossing:
 
 - **Primitive imports are fine.** Types, pure functions, and presentational components MAY be imported across feature boundaries. They are not behaviour coupling — they are shared primitives. Example: `features/account_details/.../X.svelte` importing `TransactionFormData` (type), `validateTransactionForm` (pure), or `RecordPriceCheckbox.svelte` (presentational) from `features/transactions/shared/` is acceptable.
-- **Behaviour imports are a code smell.** A reactive module or store imported from another feature couples the two features behaviourally and typically signals one of: wrong feature boundary, missing shared layer, or a piece of behaviour that should be promoted to `ui/modules/` or `shell/`. Treat the import as SHOULD-NOT and prefer promotion when it appears twice.
+- **Behaviour imports are a code smell.** A reactive module or store imported from another feature couples the two features behaviourally and typically signals one of: wrong feature boundary, missing shared layer, or a piece of behaviour that should be promoted (see destinations below). Treat the import as SHOULD-NOT and prefer promotion when it appears twice.
 
-Promotion destinations (see F28): generic UI reactive modules → `ui/modules/`; app-wide stores → `shell/`; cross-cutting platform adapters → `infra/`.
+Promotion destinations (see F28): generic UI reactive modules → `ui/modules/`; app-wide stores → `infra/cache/` (BE/FE data) or `infra/settings/` (FE prefs); cross-cutting platform adapters → `infra/`.

--- a/kit/docs/frontend-rules.md
+++ b/kit/docs/frontend-rules.md
@@ -36,14 +36,18 @@ src/
 │   └── hooks/                         ← generic React hooks (useFuzzySearch, …)
 │       └── useFuzzySearch.ts
 │
-├── infra/                             ← platform adapters ONLY (F15)
+├── infra/                             ← platform adapters + app-wide singleton state (F15, F28)
 │   ├── logger.ts                      ← native / console logger sink
-│   └── i18n/                          ← F16 i18n runtime adapter
-│       ├── index.ts                   ← setupI18n() initializer
-│       ├── config.ts
-│       └── locales/                   ← translation JSON files (per i18n-rules.md)
-│           └── {locale}/
-│               └── common.json
+│   ├── i18n/                          ← F16 i18n runtime adapter
+│   │   ├── index.ts                   ← setupI18n() initializer
+│   │   ├── config.ts
+│   │   └── locales/                   ← translation JSON files (per i18n-rules.md)
+│   │       └── {locale}/
+│   │           └── common.json
+│   ├── cache/                         ← BE/FE shared data cache (Zustand singleton, F28 Store kinds)
+│   │   └── useCacheStore.ts
+│   └── settings/                      ← FE-persisted UI prefs (theme, locale, layout)
+│       └── useSettingsStore.ts
 │
 ├── assets/                            ← images, fonts, SVGs imported by code (framework exception)
 ├── styles/                            ← global CSS, theme tokens (framework exception)
@@ -64,9 +68,23 @@ Each bucket's mandate:
 - **`features/`** — User-facing surfaces, organised per F1. A feature MAY own a gateway. **REJECTS:** anything reusable across features (promote to `ui/`) or any cross-cutting platform adapter (promote to `infra/`). A feature folder appearing anywhere else in the tree (e.g. inside `infra/` or `ui/`) is a misclassification.
 - **`shell/`** — Layout chrome ONLY: AppShell, persistent header/sidebar/content slot, app-level overlay hosts (snackbar mount point, modal portal target). Single instance per app, not reusable. **REJECTS:** `App.tsx` (root), `router.tsx` (root), anything reusable (`ui/`), anything feature-scoped (`features/`).
 - **`ui/`** — Reusable UI primitives: widgets in `ui/components/`, cross-feature formatters in `ui/format/`, generic React hooks in `ui/hooks/`. Widget runtime state colocates with the widget (e.g. `ui/components/snackbar/snackbarStore.ts`). **REJECTS:** any domain term, any Tauri call (no `commands.*` from `ui/`), any platform adapter (`infra/`).
-- **`infra/`** — Platform adapters ONLY: code that talks to a runtime outside our control (logger sink, browser storage, i18n runtime, native bridges). **REJECTS:** pure helpers and formatters (promote to `ui/format/`), generic UI hooks (promote to `ui/hooks/`), stateful UI runtime (colocate with the widget in `ui/components/`), anything feature-scoped (`features/`).
+- **`infra/`** — Platform adapters AND app-wide singleton state. Platform adapters: code that talks to a runtime outside our control (logger sink, browser storage, i18n runtime, native bridges). App-wide state: BE/FE shared data cache (`infra/cache/`), FE-persisted settings (`infra/settings/`) — see **Store kinds** below. **REJECTS:** pure helpers and formatters (promote to `ui/format/`), generic UI hooks (promote to `ui/hooks/`), widget-local UI runtime (colocate with the widget in `ui/components/`), anything feature-scoped (`features/`).
 
 When a file lands in the wrong bucket, the exclusion rule of the destination bucket is what flags it.
+
+### Store kinds
+
+Stateful UI state has three legitimate homes, distinguished by scope:
+
+| Kind                   | Description                          | Home                    |
+| ---------------------- | ------------------------------------ | ----------------------- |
+| BE/FE shared cache     | Singleton of backend-projection data | `infra/cache/`          |
+| FE-persisted settings  | UI prefs (theme, locale, layout)     | `infra/settings/`       |
+| Feature-local UI state | Single-feature draft/modal state     | `features/{x}/store.ts` |
+
+The shared cache is seeded by initial fetches and updated via Tauri events. Cross-feature reads of the shared cache MUST go through each feature's own gateway (which reads selectors from the cache); direct cross-feature store imports remain a SHOULD-NOT per **F26**.
+
+Widget-local runtime state (e.g. snackbar mount internals) stays colocated with the widget in `ui/components/`. The `infra/` exclusion above refers only to that widget-local case — app-wide singletons are explicitly included.
 
 **Framework-resource exception.** Static resources owned by the framework (not by application code) sit outside the 4-bucket discipline because the industry-standard Vite convention is well-established and tools (build, bundler, dev server) expect those paths:
 
@@ -292,6 +310,6 @@ The only authorised cross-feature navigation wiring points are:
 **F26** — Cross-feature imports are evaluated by what is imported, not by the fact of crossing:
 
 - **Primitive imports are fine.** Types, pure functions, and presentational components MAY be imported across feature boundaries. They are not behaviour coupling — they are shared primitives. Example: `features/account_details/.../X.tsx` importing `TransactionFormData` (type), `validateTransactionForm` (pure), or `RecordPriceCheckbox` (presentational) from `features/transactions/shared/` is acceptable.
-- **Behaviour imports are a code smell.** A hook or store imported from another feature couples the two features behaviourally and typically signals one of: wrong feature boundary, missing shared layer, or a piece of behaviour that should be promoted to `ui/hooks/` or `shell/`. Treat the import as SHOULD-NOT and prefer promotion when it appears twice.
+- **Behaviour imports are a code smell.** A hook or store imported from another feature couples the two features behaviourally and typically signals one of: wrong feature boundary, missing shared layer, or a piece of behaviour that should be promoted (see destinations below). Treat the import as SHOULD-NOT and prefer promotion when it appears twice.
 
-Promotion destinations (see F28): generic UI hooks → `ui/hooks/`; app-wide stores → `shell/`; cross-cutting platform adapters → `infra/`.
+Promotion destinations (see F28): generic UI hooks → `ui/hooks/`; app-wide stores → `infra/cache/` (BE/FE data) or `infra/settings/` (FE prefs); cross-cutting platform adapters → `infra/`.

--- a/kit/skills/start/SKILL.md
+++ b/kit/skills/start/SKILL.md
@@ -71,7 +71,13 @@ Before outputting anything, run `git branch --show-current` to check the current
 
 ### Step 4 — Output working context
 
-Emit the working context per the **Output format** section below, immediately after the branch check. This block is the main agent's session context — it drives the rest of the work.
+Emit the working context per the **Output format** section below, immediately after the branch check. This block is the main agent's session contract — Step 5 then mirrors it into the task tracker.
+
+### Step 5 — Set up task tracking
+
+After emitting the Working Context, immediately call `TaskCreate` once per checklist item in the template (every `- [ ]` line). Mark the first task `in_progress` BEFORE invoking the first checklist item.
+
+The checklist in the Working Context is a contract surface for the user; the `TaskCreate` entries are the agent's progress tracker for the harness. They serve different audiences — both are required, not interchangeable.
 
 ---
 
@@ -88,6 +94,9 @@ Pick the template matching the chosen workflow. Replace `{task}` with the user's
 **Type**: {type}
 **Branch**: {branch}
 **Workflow**: A — Full Feature Workflow
+
+> Use `TaskCreate` / `TaskUpdate` throughout to track progress.
+> Create one `TaskCreate` entry per checklist item below NOW, before executing the first item.
 
 ### Phase 1 — Spec & Contract & Plan _(main agent: opus)_
 - [ ] `/spec-writer` → `docs/spec/{feature}.md`
@@ -149,6 +158,7 @@ Pick the template matching the chosen workflow. Replace `{task}` with the user's
 ### Steps
 
 > Use `TaskCreate` / `TaskUpdate` throughout to track progress.
+> Create one `TaskCreate` entry per checklist item below NOW, before executing the first item.
 
 - [ ] Analyze: read relevant docs and code
 - [ ] Propose plan in chat → wait for user validation

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -118,6 +118,7 @@ class KitChecker:
         self._check_no_compound_shell_in_prompts()
         self._check_start_template_references()
         self._check_skill_conventions()
+        self._check_skills_with_checklists_seed_tasks()
         self._check_workflow_gate_drift()
 
         self._print_artifact_metrics()
@@ -677,6 +678,93 @@ class KitChecker:
             return False
 
         self.results["Skill conventions"] = True
+        return True
+
+    def _check_skills_with_checklists_seed_tasks(self) -> bool:
+        """Verify skills that emit an agent workflow checklist also instruct TaskCreate seeding.
+
+        Without this lint, a skill can ship a workflow checklist in its Output
+        format that the main agent uses as its visible plan but never mirrors
+        into the harness task tracker — silent progress loss across long
+        workflows. This is the gh#62 class of drift, observed in the
+        VaultCompass session that opened the issue.
+
+        Detection: scan `kit/skills/*/SKILL.md`. A fenced block is an "agent
+        workflow checklist" when it contains `- [ ]` items AND at least one
+        of the workflow markers (`### Phase`, `### Steps`, `**Workflow**:`).
+        PR bodies / issue templates / test plans use `- [ ]` for human
+        reviewer ticks and lack these markers — those are skipped. When an
+        agent workflow checklist is detected, the skill body MUST mention
+        `TaskCreate` outside fenced blocks.
+
+        Known limitation: the fence detector tracks ``` toggles only; a
+        skill using 4-backtick fences to wrap content with triple backticks
+        would corrupt the in-fence state for the rest of the file. Not
+        currently exercised by any kit-shipped skill.
+        """
+        fence_re = re.compile(r"^```")
+        checkbox_re = re.compile(r"^\s*- \[ \]")
+        # `\s` (not `\b`) after Phase/Steps — `\b` would accept `### Phase-out`
+        # as a workflow marker, which it isn't.
+        workflow_marker_re = re.compile(
+            r"^(?:###\s+Phase\s|###\s+Steps\s*$|\*\*Workflow\*\*:)"
+        )
+
+        failures: list[str] = []
+        for skill_path in sorted((REPO_ROOT / "kit" / "skills").glob("*/SKILL.md")):
+            content = skill_path.read_text(encoding="utf-8")
+            rel = str(skill_path.relative_to(REPO_ROOT))
+
+            # Walk the file. Track fenced blocks; for each fenced block,
+            # remember whether it contained both a workflow marker AND a
+            # checkbox. Outside fences we collect body lines for the
+            # TaskCreate-mention check.
+            in_fence = False
+            current_block_has_marker = False
+            current_block_has_checkbox = False
+            file_has_workflow_block = False  # set if ANY fenced block in file qualifies
+            body_lines: list[str] = []
+
+            for line in content.splitlines():
+                if fence_re.match(line):
+                    # Per-block flags are evaluated only on fence CLOSE
+                    # (asymmetric on purpose — reset both on close).
+                    if in_fence:
+                        if current_block_has_marker and current_block_has_checkbox:
+                            file_has_workflow_block = True
+                        current_block_has_marker = False
+                        current_block_has_checkbox = False
+                    in_fence = not in_fence
+                    continue
+                if in_fence:
+                    if workflow_marker_re.match(line):
+                        current_block_has_marker = True
+                    if checkbox_re.match(line):
+                        current_block_has_checkbox = True
+                else:
+                    body_lines.append(line)
+
+            if not file_has_workflow_block:
+                continue  # no agent workflow checklist — exempt
+
+            body = "\n".join(body_lines)
+            if "TaskCreate" not in body:
+                failures.append(f"{rel}")
+
+        if failures:
+            print("  Checklist skills seed tasks...")
+            print(
+                "    Rule: a skill emitting a fenced workflow checklist "
+                "(Phase / Steps / Workflow markers + - [ ] items) must also "
+                "instruct TaskCreate in its body."
+            )
+            for f in failures:
+                print(f"    ✗ {f}")
+            self.suite_failed = True
+            self.results["Checklist skills seed tasks"] = False
+            return False
+
+        self.results["Checklist skills seed tasks"] = True
         return True
 
     def _check_start_template_references(self) -> bool:


### PR DESCRIPTION
## Summary
- Cherry-picks all 4 v4.14 commits from main: `/start` TaskCreate Step 5 (gh#62), F28 Store kinds + F26 promotion (gh#63), reviewer-frontend F26 store-import detector (gh#64), check.py preflight lint preventing gh#62-class drift
- Mirrors 2 forked files to their `-svelte` variants with Svelte-idiom translations:
  - `frontend-rules-svelte.md`: `Zustand singleton` → `Svelte store singleton (writable / runes)`; `useCacheStore.ts` → `cacheStore.svelte.ts`; same architectural concept (3 store kinds, 3 homes)
  - `reviewer-frontend-svelte.md`: F26 detector switched from React's `useXStore` symbol-shape regex to a path-based detector (Svelte stores have no naming convention; the `@/features/X/store(.svelte)?` path is the reliable signal)
- Mirror decisions logged in `docs/svelte-mirror-log.md` — 0 skipped, every v4.14 concept transferred

## Test plan
- [ ] `just check` passes
- [ ] After merge: tag `svelte-v0.9.0+4.14.0` (minor svelte bump — main carries `feat`s)

Tracks: main@v4.14.0 (#65)
