### PR TITLE
fix: v4.18.1 — biome space indent + F28 store example

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,6 +2,6 @@
 
 ## Candidates
 
-_None — add new items as they're identified._
+- **`test_convention.md` store example lags F28 (gh#73).** The "Seeding Zustand store" example in `kit/docs/test_convention.md` imports `useAppStore` from `@/shell/appStore`, but F28 in `kit/docs/frontend-rules.md` places the BE/FE shared cache singleton in `infra/cache/` (`useCacheStore.ts`) — `shell/` explicitly rejects app-wide state. The canonical doc teaches a pattern the `reviewer-frontend` F28 grep flags. Fix: align the example to `@/infra/cache/useCacheStore`. The `-svelte` fork (`test_convention-svelte.md`) carries the same pattern but is a separate `svelte-main`-stream decision.
 
 ## Experimental

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,6 +2,6 @@
 
 ## Candidates
 
-_None — add new items as they're identified._
+- **`visual-proof-capture.mjs` ships tab-indented, fails downstream biome (gh#77).** The kit's `just format`/`lint-scripts` run biome with no project config, so biome's default `indentStyle: tab` formats the shipped `.mjs` with tabs. Downstream projects pin `indentStyle: space`, so the synced file fails their biome on every sync. Fix: add `--indent-style=space` to the kit's biome CLI invocations (no project config — preserves the "CLI flags only" design) and reformat the `.mjs`.
 
 ## Experimental

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,6 +2,6 @@
 
 ## Candidates
 
-- **`visual-proof-capture.mjs` ships tab-indented, fails downstream biome (gh#77).** The kit's `just format`/`lint-scripts` run biome with no project config, so biome's default `indentStyle: tab` formats the shipped `.mjs` with tabs. Downstream projects pin `indentStyle: space`, so the synced file fails their biome on every sync. Fix: add `--indent-style=space` to the kit's biome CLI invocations (no project config — preserves the "CLI flags only" design) and reformat the `.mjs`.
+_None — add new items as they're identified._
 
 ## Experimental

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,6 +2,6 @@
 
 ## Candidates
 
-- **`test_convention.md` store example lags F28 (gh#73).** The "Seeding Zustand store" example in `kit/docs/test_convention.md` imports `useAppStore` from `@/shell/appStore`, but F28 in `kit/docs/frontend-rules.md` places the BE/FE shared cache singleton in `infra/cache/` (`useCacheStore.ts`) — `shell/` explicitly rejects app-wide state. The canonical doc teaches a pattern the `reviewer-frontend` F28 grep flags. Fix: align the example to `@/infra/cache/useCacheStore`. The `-svelte` fork (`test_convention-svelte.md`) carries the same pattern but is a separate `svelte-main`-stream decision.
+_None — add new items as they're identified._
 
 ## Experimental

--- a/justfile
+++ b/justfile
@@ -7,13 +7,15 @@ format:
     ruff format scripts/ kit/scripts/
     ruff check --fix scripts/ kit/scripts/
     shfmt -i 4 -w kit/scripts/ kit/githooks/ kit/sync-config.sh
-    npx --yes @biomejs/biome check --write --line-width=100 kit/scripts/
+    npx --yes @biomejs/biome check --write --line-width=100 --indent-style=space kit/scripts/
     npx prettier --write "**/*.md" --ignore-path .gitignore
 
-# Lint kit-shipped scripts against tool defaults — catches files that would
-# fail downstream linters at first sync. biome (recommended + lineWidth=100),
-# ruff (kit-default selection), shellcheck (default). No project config; CLI
-# flags only — the kit is not a Node/Python project, only ships scripts.
+# Lint kit-shipped scripts against the conventions they must satisfy downstream
+# — catches files that would fail downstream linters at first sync. biome
+# (recommended + lineWidth=100 + space indent — biome's default is tab, the
+# minority convention, so space is pinned explicitly), ruff (kit-default
+# selection), shellcheck (default). No project config; CLI flags only — the kit
+# is not a Node/Python project, only ships scripts.
 lint-scripts:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -24,9 +26,9 @@ lint-scripts:
     # as scripts/sync-config.sh but lives outside kit/scripts/.
     sh=$( { find kit/scripts -maxdepth 1 -type f -name '*.sh'; echo kit/sync-config.sh; } | sort)
     if [ -n "$mjs" ]; then
-        echo "▶ biome check (lineWidth=100): $(echo "$mjs" | wc -l) file(s)"
+        echo "▶ biome check (lineWidth=100, space indent): $(echo "$mjs" | wc -l) file(s)"
         # shellcheck disable=SC2086  # word-splitting intentional for the file list
-        npx --yes @biomejs/biome check --line-width=100 $mjs || fail=1
+        npx --yes @biomejs/biome check --line-width=100 --indent-style=space $mjs || fail=1
     fi
     if [ -n "$py" ]; then
         echo "▶ ruff check + format --check: $(echo "$py" | wc -l) file(s)"

--- a/kit/docs/test_convention.md
+++ b/kit/docs/test_convention.md
@@ -73,11 +73,11 @@ vi.mock("@/ui/components/snackbar/snackbarStore", () => ({
 Inject store state directly in `beforeEach`:
 
 ```ts
-import { useAppStore } from "@/shell/appStore";
+import { useCacheStore } from "@/infra/cache/useCacheStore";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  useAppStore.setState({
+  useCacheStore.setState({
     items: [{ id: "item-1", name: "Example item" }],
   });
 });

--- a/kit/scripts/visual-proof-capture.mjs
+++ b/kit/scripts/visual-proof-capture.mjs
@@ -32,8 +32,8 @@ const STATES = (process.env.VP_STATES || "idle").split(",");
 const MASK_SELECTORS = (process.env.VP_MASK || "").split(",").filter(Boolean);
 
 if (!PORT || !HOST || !NAME) {
-	console.error("error: VP_PORT, VP_HOST, and VP_NAME are required");
-	process.exit(2);
+  console.error("error: VP_PORT, VP_HOST, and VP_NAME are required");
+  process.exit(2);
 }
 
 const consoleErrors = [];
@@ -41,46 +41,46 @@ await mkdir("screenshots", { recursive: true });
 
 const browser = await chromium.launch({ args: ["--no-sandbox"] });
 try {
-	for (const scheme of ["light", "dark"]) {
-		const context = await browser.newContext({
-			colorScheme: scheme,
-			viewport: { width: 1600, height: 900 },
-		});
-		try {
-			const page = await context.newPage();
+  for (const scheme of ["light", "dark"]) {
+    const context = await browser.newContext({
+      colorScheme: scheme,
+      viewport: { width: 1600, height: 900 },
+    });
+    try {
+      const page = await context.newPage();
 
-			page.on("console", (msg) => {
-				if (msg.type() === "error") {
-					consoleErrors.push({ scheme, text: msg.text() });
-				}
-			});
+      page.on("console", (msg) => {
+        if (msg.type() === "error") {
+          consoleErrors.push({ scheme, text: msg.text() });
+        }
+      });
 
-			const url = `http://${HOST}:${PORT}/preview.html${scheme === "dark" ? "?theme=dark" : ""}`;
-			await page.goto(url, { waitUntil: "domcontentloaded" });
-			await page.waitForSelector(`#state-${STATES[0]}`, { timeout: 10000 });
+      const url = `http://${HOST}:${PORT}/preview.html${scheme === "dark" ? "?theme=dark" : ""}`;
+      await page.goto(url, { waitUntil: "domcontentloaded" });
+      await page.waitForSelector(`#state-${STATES[0]}`, { timeout: 10000 });
 
-			const masks = MASK_SELECTORS.map((sel) => page.locator(sel));
+      const masks = MASK_SELECTORS.map((sel) => page.locator(sel));
 
-			for (const state of STATES) {
-				const el = page.locator(`#state-${state}`);
-				if ((await el.count()) > 0) {
-					const path = `screenshots/${NAME}-${scheme}-${state}.png`;
-					await el.screenshot({ path, mask: masks });
-					console.error(`  → ${path}`);
-				}
-			}
-		} finally {
-			await context.close();
-		}
-	}
+      for (const state of STATES) {
+        const el = page.locator(`#state-${state}`);
+        if ((await el.count()) > 0) {
+          const path = `screenshots/${NAME}-${scheme}-${state}.png`;
+          await el.screenshot({ path, mask: masks });
+          console.error(`  → ${path}`);
+        }
+      }
+    } finally {
+      await context.close();
+    }
+  }
 
-	if (consoleErrors.length > 0) {
-		console.error("\n⚠️  Console errors detected during capture:");
-		for (const err of consoleErrors) {
-			console.error(`  [${err.scheme}] ${err.text}`);
-		}
-		await writeFile("screenshots/.console-errors.json", JSON.stringify(consoleErrors, null, 2));
-	}
+  if (consoleErrors.length > 0) {
+    console.error("\n⚠️  Console errors detected during capture:");
+    for (const err of consoleErrors) {
+      console.error(`  [${err.scheme}] ${err.text}`);
+    }
+    await writeFile("screenshots/.console-errors.json", JSON.stringify(consoleErrors, null, 2));
+  }
 } finally {
-	await browser.close();
+  await browser.close();
 }


### PR DESCRIPTION
## Summary

- **gh#77 — biome indent (`fix`)**: the kit's `just format`/`check` ran biome with no project config, so biome's default `indentStyle: tab` formatted the shipped `visual-proof-capture.mjs` with tabs — which fails every downstream project's space-pinned biome on each sync. Added `--indent-style=space` to the kit's biome CLI invocations (no project config — preserves the "CLI flags only" design) and reformatted the `.mjs`.
- **gh#73 — F28 store example (`docs`)**: the "Seeding Zustand store" example in `kit/docs/test_convention.md` imported `useAppStore` from `@/shell/appStore`, contradicting F28 (BE/FE shared cache lives in `infra/cache/`). Aligned it to `@/infra/cache/useCacheStore`.

Patch release (fix + docs, no feature) → **v4.18.1**.

## Test plan

- [ ] `just check` passes green
- [ ] biome check reports space indent on the shipped `.mjs`

Closes #77
Closes #73
