### PR TITLE
fix: port v4.18.1 to svelte-main

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,6 +2,6 @@
 
 ## Candidates
 
-_None — add new items as they're identified._
+- **`test_convention.md` store example lags F28 (gh#73).** The "Seeding Zustand store" example in `kit/docs/test_convention.md` imports `useAppStore` from `@/shell/appStore`, but F28 in `kit/docs/frontend-rules.md` places the BE/FE shared cache singleton in `infra/cache/` (`useCacheStore.ts`) — `shell/` explicitly rejects app-wide state. The canonical doc teaches a pattern the `reviewer-frontend` F28 grep flags. Fix: align the example to `@/infra/cache/useCacheStore`. The `-svelte` fork (`test_convention-svelte.md`) carries the same pattern but is a separate `svelte-main`-stream decision.
 
 ## Experimental

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,6 +2,6 @@
 
 ## Candidates
 
-_None — add new items as they're identified._
+- **`visual-proof-capture.mjs` ships tab-indented, fails downstream biome (gh#77).** The kit's `just format`/`lint-scripts` run biome with no project config, so biome's default `indentStyle: tab` formats the shipped `.mjs` with tabs. Downstream projects pin `indentStyle: space`, so the synced file fails their biome on every sync. Fix: add `--indent-style=space` to the kit's biome CLI invocations (no project config — preserves the "CLI flags only" design) and reformat the `.mjs`.
 
 ## Experimental

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,6 +2,6 @@
 
 ## Candidates
 
-- **`visual-proof-capture.mjs` ships tab-indented, fails downstream biome (gh#77).** The kit's `just format`/`lint-scripts` run biome with no project config, so biome's default `indentStyle: tab` formats the shipped `.mjs` with tabs. Downstream projects pin `indentStyle: space`, so the synced file fails their biome on every sync. Fix: add `--indent-style=space` to the kit's biome CLI invocations (no project config — preserves the "CLI flags only" design) and reformat the `.mjs`.
+_None — add new items as they're identified._
 
 ## Experimental

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,6 +2,6 @@
 
 ## Candidates
 
-- **`test_convention.md` store example lags F28 (gh#73).** The "Seeding Zustand store" example in `kit/docs/test_convention.md` imports `useAppStore` from `@/shell/appStore`, but F28 in `kit/docs/frontend-rules.md` places the BE/FE shared cache singleton in `infra/cache/` (`useCacheStore.ts`) — `shell/` explicitly rejects app-wide state. The canonical doc teaches a pattern the `reviewer-frontend` F28 grep flags. Fix: align the example to `@/infra/cache/useCacheStore`. The `-svelte` fork (`test_convention-svelte.md`) carries the same pattern but is a separate `svelte-main`-stream decision.
+_None — add new items as they're identified._
 
 ## Experimental

--- a/docs/svelte-mirror-log.md
+++ b/docs/svelte-mirror-log.md
@@ -6,6 +6,25 @@ This file lives on `svelte-main` only — never cherry-picked back to `main`.
 
 ---
 
+## svelte-v0.13.0+4.18.0 → svelte-v0.13.1+4.18.1
+
+Baseline: `+4.18.0`. New baseline: `+4.18.1`. Patch release — two fixes, no feature: **gh#73** (the `test_convention.md` "Seeding store" example contradicted F28, pointing at `@/shell/appStore` instead of the `infra/cache/` singleton) and **gh#77** (the kit's flagless biome formatted the shipped `visual-proof-capture.mjs` with tabs — biome's default — which fails every downstream's space-pinned biome on each sync). Cherry-picked `1c9ce37..87c58be` (4 commits, dropped `chore: release v4.18.1` per usual).
+
+### Mirrored to `-svelte` variants
+
+- `kit/docs/test_convention-svelte.md` — mirrored the gh#73 F28 fix to the fork, translated to the Svelte idiom: `appStore` from `@/shell/appStore.svelte` → `cacheStore` from `@/infra/cache/cacheStore.svelte` (per `frontend-rules-svelte.md` F28, `infra/cache/cacheStore.svelte.ts`), keeping the runes-store `.reset()` seeding pattern rather than React's `.setState()`. Commit `26e2669`.
+
+### Adjusted at cherry-pick (content auto-merge)
+
+- `justfile` — git auto-merged the gh#77 biome change (`--indent-style=space` added to the `format` and `lint-scripts` recipes) while preserving the Svelte-only `merge-svelte` recipe. Verified: both biome flags present, `merge-svelte` intact, no markers.
+
+### Shared — no fork, applied as-is
+
+- `kit/scripts/visual-proof-capture.mjs` — single shared file; gh#77 reindented it tabs→spaces (pure whitespace). No `-svelte` variant.
+- `docs/TODO.md` — kit-internal planning, not synced, no fork.
+
+`just check` passes green on the ported branch.
+
 ## svelte-v0.12.0+4.17.0 → svelte-v0.13.0+4.18.0
 
 Baseline: `+4.17.0`. New baseline: `+4.18.0`. v4.18 carries three themes: the **spec-writer coverage scan** (graded business-behaviour taxonomy forcing genuine open questions, with `spec-reviewer` cross-check), the **db/no-db sync selection** surface (`"database"` flag in `kit.config.json` excluding the `reviewer-sql` agent + `migrate`/`prepare-sqlx`/`clean-db` recipes when false), and **CI parity** (`just check` as the single gate shared by CI and local). Cherry-picked `c49fc25..bc8b94a` (8 commits, dropped `chore: release v4.18.0` per usual).

--- a/justfile
+++ b/justfile
@@ -7,13 +7,15 @@ format:
     ruff format scripts/ kit/scripts/
     ruff check --fix scripts/ kit/scripts/
     shfmt -i 4 -w kit/scripts/ kit/githooks/ kit/sync-config.sh
-    npx --yes @biomejs/biome check --write --line-width=100 kit/scripts/
+    npx --yes @biomejs/biome check --write --line-width=100 --indent-style=space kit/scripts/
     npx prettier --write "**/*.md" --ignore-path .gitignore
 
-# Lint kit-shipped scripts against tool defaults — catches files that would
-# fail downstream linters at first sync. biome (recommended + lineWidth=100),
-# ruff (kit-default selection), shellcheck (default). No project config; CLI
-# flags only — the kit is not a Node/Python project, only ships scripts.
+# Lint kit-shipped scripts against the conventions they must satisfy downstream
+# — catches files that would fail downstream linters at first sync. biome
+# (recommended + lineWidth=100 + space indent — biome's default is tab, the
+# minority convention, so space is pinned explicitly), ruff (kit-default
+# selection), shellcheck (default). No project config; CLI flags only — the kit
+# is not a Node/Python project, only ships scripts.
 lint-scripts:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -24,9 +26,9 @@ lint-scripts:
     # as scripts/sync-config.sh but lives outside kit/scripts/.
     sh=$( { find kit/scripts -maxdepth 1 -type f -name '*.sh'; echo kit/sync-config.sh; } | sort)
     if [ -n "$mjs" ]; then
-        echo "▶ biome check (lineWidth=100): $(echo "$mjs" | wc -l) file(s)"
+        echo "▶ biome check (lineWidth=100, space indent): $(echo "$mjs" | wc -l) file(s)"
         # shellcheck disable=SC2086  # word-splitting intentional for the file list
-        npx --yes @biomejs/biome check --line-width=100 $mjs || fail=1
+        npx --yes @biomejs/biome check --line-width=100 --indent-style=space $mjs || fail=1
     fi
     if [ -n "$py" ]; then
         echo "▶ ruff check + format --check: $(echo "$py" | wc -l) file(s)"

--- a/kit/docs/test_convention-svelte.md
+++ b/kit/docs/test_convention-svelte.md
@@ -74,11 +74,11 @@ vi.mock("@/ui/components/snackbar/snackbarStore.svelte", () => ({
 For app-wide reactive state in a `.svelte.ts` module, expose a `reset()` (or test-only setter) and call it in `beforeEach`:
 
 ```ts
-import { appStore } from "@/shell/appStore.svelte";
+import { cacheStore } from "@/infra/cache/cacheStore.svelte";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  appStore.reset({
+  cacheStore.reset({
     items: [{ id: "item-1", name: "Example item" }],
   });
 });

--- a/kit/docs/test_convention.md
+++ b/kit/docs/test_convention.md
@@ -73,11 +73,11 @@ vi.mock("@/ui/components/snackbar/snackbarStore", () => ({
 Inject store state directly in `beforeEach`:
 
 ```ts
-import { useAppStore } from "@/shell/appStore";
+import { useCacheStore } from "@/infra/cache/useCacheStore";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  useAppStore.setState({
+  useCacheStore.setState({
     items: [{ id: "item-1", name: "Example item" }],
   });
 });

--- a/kit/scripts/visual-proof-capture.mjs
+++ b/kit/scripts/visual-proof-capture.mjs
@@ -32,8 +32,8 @@ const STATES = (process.env.VP_STATES || "idle").split(",");
 const MASK_SELECTORS = (process.env.VP_MASK || "").split(",").filter(Boolean);
 
 if (!PORT || !HOST || !NAME) {
-	console.error("error: VP_PORT, VP_HOST, and VP_NAME are required");
-	process.exit(2);
+  console.error("error: VP_PORT, VP_HOST, and VP_NAME are required");
+  process.exit(2);
 }
 
 const consoleErrors = [];
@@ -41,46 +41,46 @@ await mkdir("screenshots", { recursive: true });
 
 const browser = await chromium.launch({ args: ["--no-sandbox"] });
 try {
-	for (const scheme of ["light", "dark"]) {
-		const context = await browser.newContext({
-			colorScheme: scheme,
-			viewport: { width: 1600, height: 900 },
-		});
-		try {
-			const page = await context.newPage();
+  for (const scheme of ["light", "dark"]) {
+    const context = await browser.newContext({
+      colorScheme: scheme,
+      viewport: { width: 1600, height: 900 },
+    });
+    try {
+      const page = await context.newPage();
 
-			page.on("console", (msg) => {
-				if (msg.type() === "error") {
-					consoleErrors.push({ scheme, text: msg.text() });
-				}
-			});
+      page.on("console", (msg) => {
+        if (msg.type() === "error") {
+          consoleErrors.push({ scheme, text: msg.text() });
+        }
+      });
 
-			const url = `http://${HOST}:${PORT}/preview.html${scheme === "dark" ? "?theme=dark" : ""}`;
-			await page.goto(url, { waitUntil: "domcontentloaded" });
-			await page.waitForSelector(`#state-${STATES[0]}`, { timeout: 10000 });
+      const url = `http://${HOST}:${PORT}/preview.html${scheme === "dark" ? "?theme=dark" : ""}`;
+      await page.goto(url, { waitUntil: "domcontentloaded" });
+      await page.waitForSelector(`#state-${STATES[0]}`, { timeout: 10000 });
 
-			const masks = MASK_SELECTORS.map((sel) => page.locator(sel));
+      const masks = MASK_SELECTORS.map((sel) => page.locator(sel));
 
-			for (const state of STATES) {
-				const el = page.locator(`#state-${state}`);
-				if ((await el.count()) > 0) {
-					const path = `screenshots/${NAME}-${scheme}-${state}.png`;
-					await el.screenshot({ path, mask: masks });
-					console.error(`  → ${path}`);
-				}
-			}
-		} finally {
-			await context.close();
-		}
-	}
+      for (const state of STATES) {
+        const el = page.locator(`#state-${state}`);
+        if ((await el.count()) > 0) {
+          const path = `screenshots/${NAME}-${scheme}-${state}.png`;
+          await el.screenshot({ path, mask: masks });
+          console.error(`  → ${path}`);
+        }
+      }
+    } finally {
+      await context.close();
+    }
+  }
 
-	if (consoleErrors.length > 0) {
-		console.error("\n⚠️  Console errors detected during capture:");
-		for (const err of consoleErrors) {
-			console.error(`  [${err.scheme}] ${err.text}`);
-		}
-		await writeFile("screenshots/.console-errors.json", JSON.stringify(consoleErrors, null, 2));
-	}
+  if (consoleErrors.length > 0) {
+    console.error("\n⚠️  Console errors detected during capture:");
+    for (const err of consoleErrors) {
+      console.error(`  [${err.scheme}] ${err.text}`);
+    }
+    await writeFile("screenshots/.console-errors.json", JSON.stringify(consoleErrors, null, 2));
+  }
 } finally {
-	await browser.close();
+  await browser.close();
 }


### PR DESCRIPTION
## Summary

Ports React **v4.18.1** (patch: gh#73 + gh#77) onto `svelte-main`. Cherry-picked `1c9ce37..87c58be` (4 commits, release commit dropped).

- **gh#77** (`fix`) — `--indent-style=space` added to the kit's biome recipes; shipped `visual-proof-capture.mjs` reformatted to spaces. `justfile` auto-merged, preserving the Svelte-only `merge-svelte` recipe.
- **gh#73** (`docs`) — F28 store-example fix, applied to the React `test_convention.md` and **mirrored** to the `test_convention-svelte.md` fork in the Svelte idiom (`cacheStore` from `@/infra/cache/cacheStore.svelte`, `.reset()` seeding).

See `docs/svelte-mirror-log.md` for the full mirror-decision record.

Next tag (manual, post-merge): `svelte-v0.13.1+4.18.1`.

## Test plan

- [ ] `just check` passes green
